### PR TITLE
Ready for review tweaks

### DIFF
--- a/.github/workflows/ready-for-review.yml
+++ b/.github/workflows/ready-for-review.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   ready_for_review:
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/github-script@v6
@@ -52,20 +53,6 @@ jobs:
             }
 
             const { pull_request: pr } = context.payload
-
-            if (pr.draft) {
-              // this workflow is expected to be called for both the 'opened'
-              // and 'ready_for_review' action types on PRs.
-              //
-              // the 'ready_for_review' type is only triggered when a draft PR
-              // is marked as ready for review, but the the 'opened' action type
-              // is triggered for draft PRs.
-              //
-              // in order to avoid sending notifications for PRs that are opened
-              // as drafts, we need to bail early from this job.
-              core.info('Skipping because PR is a draft')
-              return
-            }
 
             return new Promise((resolve) => {
               // actions/github-script@v6 uses Node 16, which does not have

--- a/.github/workflows/ready-for-review.yml
+++ b/.github/workflows/ready-for-review.yml
@@ -17,7 +17,8 @@ on:
     types: [opened, ready_for_review]
 
 jobs:
-  ready_for_review:
+  notify_slack:
+    name: Notify Slack
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/ready-for-review.yml
+++ b/.github/workflows/ready-for-review.yml
@@ -2,6 +2,13 @@ name: Run jobs if ready for review
 
 on:
   workflow_call:
+    inputs:
+      slack_repo_emoji:
+        description: ':slack-style: emoji to help identify the repo in Slack notifications'
+        type: string
+        required: false
+        default: ':octocat:'
+
     secrets:
       SLACK_READY_FOR_REVIEW_WEBHOOK_URL:
         description: 'Slack webhook to call to trigger the Slack workflow'
@@ -25,6 +32,7 @@ jobs:
       - uses: actions/github-script@v6
         continue-on-error: true # avoid failing the build if we can't send the notification
         env:
+          SLACK_REPO_EMOJI: ${{ inputs.slack_repo_emoji }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_READY_FOR_REVIEW_WEBHOOK_URL }}
         with:
           script: |
@@ -63,6 +71,7 @@ jobs:
 
               const payload = {
                 repo_name: context.repo.repo,
+                repo_emoji: process.env.SLACK_REPO_EMOJI,
                 pr_url: pr.html_url,
                 pr_number: pr.number,
                 pr_title: pr.title,

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-r
 ---
 
 > **Warning**
-> 
+>
 > ## This is a public repo!
 >
 > **Be extra careful with any commits that you make to this repo.**
@@ -38,7 +38,10 @@ on:
 
 jobs:
   ready_for_review:
+    name: 'Ready for Review'
     uses: ForwardFinancing/github-workflows/.github/workflows/ready-for-review.yml@main
+    with:
+      slack_repo_emoji: ':octocat:'
     secrets:
       SLACK_READY_FOR_REVIEW_WEBHOOK_URL: ${{ secrets.SLACK_READY_FOR_REVIEW_WEBHOOK_URL }}
 ```


### PR DESCRIPTION
This PR:

- moves the draft check out of the JS and into the YAML (hopefully it works 🤞)
  - this will make it easier to copy-paste the same check if we add additional jobs to the "Ready for Review" workflow
- renames the `ready_for_review` job to `notify_slack` (and adds a prettified name for the GitHub UI)
  - this is mostly to make the name more meaningful in the PR Checks UI
- adds support for sending an emoji to the Slack workflow
  - this probably seems like an unnecessarily cutesy feature, but on a practical level I think the emojis will make it easier to glance at a channel and quickly discover if any PRs are in repos that you're interested in
  - without the emojis, we get a constant stream of messages that all look _very_ similar, which (IMO) makes it difficult to scan
  - ...also I like emojis 🙃